### PR TITLE
Proposed fix to not include whitespace vnodes when determining zIndex

### DIFF
--- a/src/components/KonvaNode.js
+++ b/src/components/KonvaNode.js
@@ -65,7 +65,7 @@ export default function() {
       let needRedraw = false;
       this.$children.forEach(component => {
         const vnode = component.$vnode;
-        const index = this.$vnode.componentOptions.children.indexOf(vnode);
+        const index = this.$vnode.componentOptions.children.filter(vnode => vnode.tag !== undefined).indexOf(vnode);
         const konvaNode = findKonvaNode(component);
         if (konvaNode.getZIndex() !== index) {
           konvaNode.setZIndex(index);


### PR DESCRIPTION
fix to remove whitespace vnodes (which coudl come from vue-loader wit…h preserveWhitespace on) when determining zIndex