### PR TITLE
avoid z-index update error by false-positive konva node detection

### DIFF
--- a/src/components/KonvaNode.js
+++ b/src/components/KonvaNode.js
@@ -4,13 +4,17 @@ import {
   findParentKonva,
   createListener,
   updatePicture,
-  findKonvaNode
+  findKonvaNode,
+  konvaNodeMarker
 } from '../utils';
 
 const EVENTS_NAMESPACE = '.vue-konva-event';
 
 export default function() {
   return {
+    // Mark it to detect whether an Vue instance is KonvaNode or not later
+    [konvaNodeMarker]: true,
+
     render(createElement) {
       return createElement('div', this.$slots.default);
     },

--- a/src/utils/index.js
+++ b/src/utils/index.js
@@ -2,6 +2,7 @@ import updatePicture from './updatePicture';
 import applyNodeProps from './applyNodeProps';
 
 export const componentPrefix = 'v';
+export const konvaNodeMarker = '_konvaNode'
 
 function camelize(str) {
   return str
@@ -47,7 +48,7 @@ export function findParentKonva(instance) {
 }
 
 export function findKonvaNode(instance) {
-  if (instance.getNode) {
+  if (instance.$options[konvaNodeMarker]) {
     return instance.getNode();
   } else if (instance.$children.length === 0) {
     return null;

--- a/tests/index-test.js
+++ b/tests/index-test.js
@@ -871,14 +871,14 @@ describe('test reconciler', () => {
   });
 
   it('change deep order', function() {
-    Vue.component('deep', {
+    const Deep = {
       props: ['name'],
       render(createElement) {
         return createElement('v-rect', {
           attrs: { config: { name: this.name } }
         });
       }
-    });
+    };
     const { vm } = mount({
       template: `
           <v-stage ref="stage">
@@ -888,6 +888,9 @@ describe('test reconciler', () => {
             </v-layer>
           </v-stage>
         `,
+      components: {
+        Deep
+      },
       data() {
         return {
           items: [1, 2, 3]
@@ -910,6 +913,51 @@ describe('test reconciler', () => {
     expect(layer.children[1].name()).to.equal('rect3');
     expect(layer.children[2].name()).to.equal('rect2');
   });
+
+
+  it('change deep order with detecting konva node correctly', () => {
+    const Deep = {
+      props: ['name'],
+      render(createElement) {
+        return createElement('v-rect', {
+          attrs: { config: { name: this.name } }
+        });
+      },
+      methods: {
+        getNode() {
+          return {}
+        }
+      }
+    };
+    const { vm } = mount({
+      template: `
+          <v-stage ref="stage">
+            <v-layer ref="layer">
+              <deep v-for="item in items" :name="'rect' + item" :key="item">
+              </deep>
+            </v-layer>
+          </v-stage>
+        `,
+      components: {
+        Deep
+      },
+      data() {
+        return {
+          items: [1, 2, 3]
+        };
+      }
+    });
+    const layer = vm.$refs.layer.getNode();
+
+    expect(layer.children[0].name()).to.equal('rect1');
+    expect(layer.children[1].name()).to.equal('rect2');
+    expect(layer.children[2].name()).to.equal('rect3');
+
+    vm.items = [3, 2, 1];
+    expect(layer.children[0].name()).to.equal('rect3');
+    expect(layer.children[1].name()).to.equal('rect2');
+    expect(layer.children[2].name()).to.equal('rect1');
+  })
 
   it('can draw several stages', function() {
     const { vm } = mount({


### PR DESCRIPTION
Hello, I found an issue while using vue-konva on my project.

The issue is that If I define some custom component having `getNode` method, vue-konva takes it as a konva node when component update which is false-positive and causes a warning.
The reproduction is here (See the console): https://codesandbox.io/s/vue-konva-method-conflict-reproduction-nokg8

In this PR, I've added a special marker in `KonvaNode` component option and let it check the marker when it finds KonvaNode to fix the issue.