### PR TITLE
Adding Vetur support

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "vue-konva",
-  "version": "2.0.11",
+  "version": "2.0.12",
   "description": "Vue binding to canvas element via Konva framework",
   "keywords": [
     "vue",
@@ -11,9 +11,14 @@
   "author": "Rafael Escala <rafaesc92@gmail.com>",
   "main": "umd/vue-konva.js",
   "types": "index.d.ts",
+  "vetur":{
+    "tags": "vetur/tags.json",
+    "attributes": "vetur/attributes.json"
+  },
   "files": [
     "umd",
-    "index.d.ts"
+    "index.d.ts",
+    "vetur/"
   ],
   "repository": {
     "type": "git",

--- a/vetur/attributes.json
+++ b/vetur/attributes.json
@@ -1,0 +1,94 @@
+{
+  "v-stage/config": {
+    "type": "object",
+    "description": "Konva config object"
+  },
+  "v-layer/config": {
+    "type": "object",
+    "description": "Konva config object"
+  },
+  "v-fast-layer/config": {
+    "type": "object",
+    "description": "Konva config object"
+  },
+  "v-group/config": {
+    "type": "object",
+    "description": "Konva config object"
+  },
+  "v-label/config": {
+    "type": "object",
+    "description": "Konva config object"
+  },
+  "v-rect/config": {
+    "type": "object",
+    "description": "Konva config object"
+  },
+  "v-circle/config": {
+    "type": "object",
+    "description": "Konva config object"
+  },
+  "v-ellipse/config": {
+    "type": "object",
+    "description": "Konva config object"
+  },
+  "v-wedge/config": {
+    "type": "object",
+    "description": "Konva config object"
+  },
+  "v-line/config": {
+    "type": "object",
+    "description": "Konva config object"
+  },
+  "v-sprite/config": {
+    "type": "object",
+    "description": "Konva config object"
+  },
+  "v-image/config": {
+    "type": "object",
+    "description": "Konva config object"
+  },
+  "v-text/config": {
+    "type": "object",
+    "description": "Konva config object"
+  },
+  "v-text-path/config": {
+    "type": "object",
+    "description": "Konva config object"
+  },
+  "v-star/config": {
+    "type": "object",
+    "description": "Konva config object"
+  },
+  "v-ring/config": {
+    "type": "object",
+    "description": "Konva config object"
+  },
+  "v-arc/config": {
+    "type": "object",
+    "description": "Konva config object"
+  },
+  "v-tag/config": {
+    "type": "object",
+    "description": "Konva config object"
+  },
+  "v-path/config": {
+    "type": "object",
+    "description": "Konva config object"
+  },
+  "v-regular-polygon/config": {
+    "type": "object",
+    "description": "Konva config object"
+  },
+  "v-arrow/config": {
+    "type": "object",
+    "description": "Konva config object"
+  },
+  "v-shape/config": {
+    "type": "object",
+    "description": "Konva config object"
+  },
+  "v-transformer/config": {
+    "type": "object",
+    "description": "Konva config object"
+  },
+}

--- a/vetur/attributes.json
+++ b/vetur/attributes.json
@@ -90,5 +90,5 @@
   "v-transformer/config": {
     "type": "object",
     "description": "Konva config object"
-  },
+  }
 }

--- a/vetur/tags.json
+++ b/vetur/tags.json
@@ -1,0 +1,163 @@
+{
+  "v-stage": {
+    "attributes": [
+      "config"
+    ],
+    "subtags": [],
+    "description": "Konva stage"
+  },
+  "v-layer": {
+    "attributes": [
+      "config"
+    ],
+    "subtags": [],
+    "description": "Konva layer"
+  },
+  "v-fast-layer": {
+    "attributes": [
+      "config"
+    ],
+    "subtags": [],
+    "description": "Konva fast layer"
+  },
+  "v-group": {
+    "attributes": [
+      "config"
+    ],
+    "subtags": [],
+    "description": "Konva group"
+  },
+  "v-label": {
+    "attributes": [
+      "config"
+    ],
+    "subtags": [],
+    "description": "Konva label"
+  },
+  "v-rect": {
+    "attributes": [
+      "config"
+    ],
+    "subtags": [],
+    "description": "Konva rectangle"
+  },
+  "v-circle": {
+    "attributes": [
+      "config"
+    ],
+    "subtags": [],
+    "description": "Konva circle"
+  },
+  "v-ellipse": {
+    "attributes": [
+      "config"
+    ],
+    "subtags": [],
+    "description": "Konva ellipse"
+  },
+  "v-wedge": {
+    "attributes": [
+      "config"
+    ],
+    "subtags": [],
+    "description": "Konva wedge"
+  },
+  "v-line": {
+    "attributes": [
+      "config"
+    ],
+    "subtags": [],
+    "description": "Konva line"
+  },
+  "v-sprite": {
+    "attributes": [
+      "config"
+    ],
+    "subtags": [],
+    "description": "Konva sprite"
+  },
+  "v-image": {
+    "attributes": [
+      "config"
+    ],
+    "subtags": [],
+    "description": "Konva image"
+  },
+  "v-text": {
+    "attributes": [
+      "config"
+    ],
+    "subtags": [],
+    "description": "Konva text"
+  },
+  "v-text-path": {
+    "attributes": [
+      "config"
+    ],
+    "subtags": [],
+    "description": "Konva text path"
+  },
+  "v-star": {
+    "attributes": [
+      "config"
+    ],
+    "subtags": [],
+    "description": "Konva star"
+  },
+  "v-ring": {
+    "attributes": [
+      "config"
+    ],
+    "subtags": [],
+    "description": "Konva ring"
+  },
+  "v-arc": {
+    "attributes": [
+      "config"
+    ],
+    "subtags": [],
+    "description": "Konva arc"
+  },
+  "v-tag": {
+    "attributes": [
+      "config"
+    ],
+    "subtags": [],
+    "description": "Konva tag"
+  },
+  "v-path": {
+    "attributes": [
+      "config"
+    ],
+    "subtags": [],
+    "description": "Konva path"
+  },
+  "v-regular-polygon": {
+    "attributes": [
+      "config"
+    ],
+    "subtags": [],
+    "description": "Konva regular polygon"
+  },
+  "v-arrow": {
+    "attributes": [
+      "config"
+    ],
+    "subtags": [],
+    "description": "Konva arrow"
+  },
+  "v-shape": {
+    "attributes": [
+      "config"
+    ],
+    "subtags": [],
+    "description": "Konva shape"
+  },
+  "v-transformer": {
+    "attributes": [
+      "config"
+    ],
+    "subtags": [],
+    "description": "Konva transformer"
+  },
+}

--- a/vetur/tags.json
+++ b/vetur/tags.json
@@ -159,5 +159,5 @@
     ],
     "subtags": [],
     "description": "Konva transformer"
-  },
+  }
 }


### PR DESCRIPTION
Vetur can provide autocomplete support for custom components through tag and attributes definition files and by linking to them under a "vetur" key in the package.json. Check out [this page](https://github.com/vuejs/vetur/blob/master/docs/framework.md) for more details.

I've incremented the patch version, moving the version from 2.0.11 to 2.0.12.

Cheers,

Jake