### PR TITLE
fix: Stage v-on event trigger twice in vue@3

### DIFF
--- a/src/components/Stage.js
+++ b/src/components/Stage.js
@@ -24,6 +24,8 @@ export default {
     },
   },
 
+  inheritAttrs: false,
+
   setup(props, { attrs, slots, expose, emits }) {
     const instance = getCurrentInstance();
     const oldProps = reactive({});

--- a/src/components/Stage.js
+++ b/src/components/Stage.js
@@ -88,6 +88,6 @@ export default {
     // Loop order test appears to be problem with an empty v-for on layer objects
     //     - When the second item is added to the list we get a Vue internals bug.
     //     - Possibly related to https://github.com/vuejs/vue-next/issues/2715
-    return () => h('template', { ref: container }, slots.default?.());
+    return () => h('div', { ref: container }, slots.default?.());
   },
 };


### PR DESCRIPTION
#182 
#195 
#192 

using `v-on` bind events on the stage component, the event listener will [fallthrough](https://vuejs.org/guide/components/attrs.html) to the `<canvas>` element, that is why the stage component event will trigger twice

![image](https://user-images.githubusercontent.com/67723917/181290271-86e9d8d1-accf-4cf9-9883-198599d91637.png)

![image](https://user-images.githubusercontent.com/67723917/181290990-57dbc2da-c7c6-44aa-9b83-a683b0259db2.png)


https://vuejs.org/api/options-misc.html#inheritattrs