### PR TITLE
feat: allow useImage() args to be any reactive value

### DIFF
--- a/src/use-image.ts
+++ b/src/use-image.ts
@@ -1,17 +1,17 @@
-import { ref, watch, Ref } from "vue";
+import { ref, computed, watch, toValue, type MaybeRefOrGetter } from "vue";
 
 export function useImage(
-  url: string | Ref<string>,
-  crossorigin?: string | Ref<string>,
-  referrerPolicy?: string | Ref<string>
+  url: MaybeRefOrGetter<string>,
+  crossorigin?: MaybeRefOrGetter<string>,
+  referrerPolicy?: MaybeRefOrGetter<string>
 ) {
   const image = ref<HTMLImageElement | null>(null);
   const status = ref<"loading" | "loaded" | "error">("loading");
 
   const load = (
     newUrl: string,
-    newCrossorigin?: string,
-    newReferrerPolicy?: string
+    newCrossorigin: string | undefined,
+    newReferrerPolicy: string | undefined,
   ) => {
     status.value = "loading";
     const img = new Image();
@@ -36,20 +36,18 @@ export function useImage(
     img.src = newUrl;
   };
 
+  const toWatchable = computed(() => ({
+    url: toValue(url),
+    crossorigin: toValue(crossorigin),
+    referrerPolicy: toValue(referrerPolicy),
+  }))
+
   // Watch for changes in url, crossorigin, and referrerPolicy
   watch(
-    [
-      typeof url === 'string' ? ref(url) : url,
-      crossorigin ? (typeof crossorigin === 'string' ? ref(crossorigin) : crossorigin) : ref(undefined),
-      referrerPolicy ? (typeof referrerPolicy === 'string' ? ref(referrerPolicy) : referrerPolicy) : ref(undefined)
-    ],
-    ([newUrl, newCrossorigin, newReferrerPolicy]) => {
-      if (newUrl) {
-        load(
-          newUrl,
-          newCrossorigin,
-          newReferrerPolicy
-        );
+    toWatchable,
+    ({ url, crossorigin, referrerPolicy }) => {
+      if (url) {
+        load(url, crossorigin, referrerPolicy);
       }
     },
     { immediate: true }

--- a/src/use-image.ts
+++ b/src/use-image.ts
@@ -10,8 +10,8 @@ export function useImage(
 
   const load = (
     newUrl: string,
-    newCrossorigin: string | undefined,
-    newReferrerPolicy: string | undefined,
+    newCrossorigin?: string,
+    newReferrerPolicy?: string,
   ) => {
     status.value = "loading";
     const img = new Image();


### PR DESCRIPTION
Hello, Vue has a more flexible approach to managing reactivity on composables with `MaybeRefOrGetter` types. Previously, with `string | Ref<string>`, `computed` or simple getter variables would not be allowed as TypeScript values of `useImage` (even though they *would* work as `typeof` would fail the string check).

On the code side, this allows:
```ts
const imageUrl = computed(() => /* ... */)
const image = useImage(imageUrl)
```

```ts
const { imageUrl } = defineProps<{
  imageUrl: string
}>()

const image = useImage(() => imageUrl)
```

There's a little perf upgrade of packaging all watchable values into one computed instead of creating up to 3 refs!

Happy to address any concerns about it :)